### PR TITLE
quality-of-life improvements for command-line usage

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+export PATH="$(pwd)/node_modules/.bin:$PATH"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 elm-stuff
 # elm-repl generated files
 repl-temp-*
+
+/node_modules


### PR DESCRIPTION
You'll have to `direnv allow` this file, but then you can call `elm` and friends installed via NPM without prefixing with `node_modules/.bin`